### PR TITLE
Stay up to date.

### DIFF
--- a/src/posts/2016-01-24_9-things-every-reactjs-beginner-should-know.md
+++ b/src/posts/2016-01-24_9-things-every-reactjs-beginner-should-know.md
@@ -301,6 +301,8 @@ const ListOfNumbers = props => (
   </ol>
 );
 
+// React.PropTypes React.PropTypes is deprecated since React 15.5.0,
+// use the npm module prop-types instead.
 ListOfNumbers.propTypes = {
   className: React.PropTypes.string.isRequired,
   numbers: React.PropTypes.arrayOf(React.PropTypes.number)


### PR DESCRIPTION
`React.PropTypes` has been deprecated use `prop-types` module instead.